### PR TITLE
fix a bug on file_field partial use args instead of properties

### DIFF
--- a/app/views/adminpanel/form/_file_field.html.erb
+++ b/app/views/adminpanel/form/_file_field.html.erb
@@ -1,4 +1,4 @@
 <% if !is_modal %>
   <% args = properties.except('name') %>
-  <%= f.file_field(attribute, properties) %>
+  <%= f.file_field(attribute, args) %>
 <% end %>


### PR DESCRIPTION
This was causing the name property of the form to be overwritten